### PR TITLE
[bugfix/server-43] Harden MySQL pool + fix async lazy-load and omit empty groups in firewall rulesets

### DIFF
--- a/server/app/db.py
+++ b/server/app/db.py
@@ -7,7 +7,13 @@ class Base(DeclarativeBase):
     pass
 
 
-engine = create_async_engine(settings.db_url, echo=False, future=True)
+engine = create_async_engine(
+    settings.db_url,
+    echo=False,
+    future=True,
+    pool_pre_ping=True,
+    pool_recycle=1800,
+)
 AsyncSessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 

--- a/server/app/models/schemas.py
+++ b/server/app/models/schemas.py
@@ -171,7 +171,7 @@ class FirewallRuleResponse(BaseModel):
     local_cidr: Optional[str]
     ca_name: Optional[str]
     ca_sha: Optional[str]
-    groups: List[GroupRef]
+    groups: Optional[List[GroupRef]] = None
 
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
- Enable pool_pre_ping and pool_recycle on async engine to avoid MySQL (2013) resets
- Avoid async lazy-load in ruleset create/update by setting rule.groups explicitly
- Make FirewallRuleResponse.groups optional and omit when empty (response_model_exclude_none)

## Summary by Sourcery

Harden MySQL connection handling and refine firewall ruleset group handling in API endpoints

Bug Fixes:
- Enable pool_pre_ping and pool_recycle on the async database engine to prevent MySQL connection resets
- Explicitly set rule.groups to an empty list during create/update to avoid unintended async lazy-loading
- Make groups in FirewallRuleResponse optional and exclude the field when it’s empty via response_model_exclude_none