### PR TITLE
[bugfix/server-43] Harden MySQL pool + fix async lazy-load and omit empty groups in firewall rulesets

### DIFF
--- a/server/app/db.py
+++ b/server/app/db.py
@@ -7,7 +7,13 @@ class Base(DeclarativeBase):
     pass
 
 
-engine = create_async_engine(settings.db_url, echo=False, future=True)
+engine = create_async_engine(
+    settings.db_url,
+    echo=False,
+    future=True,
+    pool_pre_ping=True,
+    pool_recycle=1800,
+)
 AsyncSessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 

--- a/server/app/models/schemas.py
+++ b/server/app/models/schemas.py
@@ -171,7 +171,7 @@ class FirewallRuleResponse(BaseModel):
     local_cidr: Optional[str]
     ca_name: Optional[str]
     ca_sha: Optional[str]
-    groups: List[GroupRef]
+    groups: Optional[List[GroupRef]] = None
 
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
## Summary by Sourcery

Harden MySQL pool behavior and improve firewall rulesets API by preventing unintended lazy loads and skipping empty group lists in responses

Bug Fixes:
- Prevent async lazy-load by explicitly initializing rule.groups to an empty list when no groups are provided

Enhancements:
- Configure SQLAlchemy engine with pool_pre_ping and pool_recycle settings for MySQL
- Add response_model_exclude_none to firewall rulesets endpoints and adjust responses to omit empty group lists
- Adjust FirewallRuleResponse schema to make groups optional