### PR TITLE
[bugfix/macos-57] Update macos-release workflow

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -46,12 +46,16 @@ jobs:
     
     - name: Build and Sign with Fastlane
       env:
-        MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        MATCH_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
         MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-        APPLE_APP_STORE_API_KEY_ID: ${{ secrets.APPLE_APP_STORE_API_KEY_ID }}
         APPLE_APPSTORE_API_ISSUER_ID: ${{ secrets.APPLE_APPSTORE_API_ISSUER_ID }}
         APPLE_APP_STORE_API_KEY: ${{ secrets.APPLE_APP_STORE_API_KEY }}
+        APPLE_APP_STORE_API_KEY_ID: ${{ secrets.APPLE_APP_STORE_API_KEY_ID }}
         VERSION: ${{ steps.get_version.outputs.VERSION }}
+        FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+        FASTLANE_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+        FASTLANE_USER: "jakumpe@justinkumpe.net"
+
       run: |
         cd macos_client
         fastlane mac build_production


### PR DESCRIPTION
Resolves #57

Update GitHub Actions workflow configuration for macOS release builds.

## Summary by Sourcery

Adjust macOS release GitHub Actions workflow to align secret names and add Fastlane credentials

CI:
- Rename MATCH_PASSWORD secret to MATCH_KEYCHAIN_PASSWORD in the macOS release workflow
- Re-position the APPLE_APP_STORE_API_KEY_ID declaration among other App Store API credentials
- Introduce FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD, FASTLANE_PASSWORD, and FASTLANE_USER environment variables for Fastlane integration