### PR TITLE
[bugfix/macos-57] fixed version for beta releases

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -56,10 +56,8 @@ jobs:
     - name: Get version from release tag
       id: get_version
       run: |
-        # Extract version from release tag (strip 'v' prefix and beta suffixes)
+        # Extract version from release tag (strip 'v' prefix, keep beta suffixes)
         VERSION="${GITHUB_REF#refs/tags/v}"
-        # Strip -beta, -beta2, etc. suffixes for release number
-        VERSION="${VERSION%%-beta*}"
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
         echo "Building version: $VERSION"
     

--- a/macos_client/create-installer.sh
+++ b/macos_client/create-installer.sh
@@ -6,6 +6,8 @@ set -e
 APP_NAME="ManagedNebula"
 # Use VERSION from environment if provided, otherwise default to 1.0.0
 VERSION="${VERSION:-1.0.0}"
+# PKG_VERSION is for pkgbuild (numeric only), strip any suffix after first dash
+PKG_VERSION="${VERSION%%-*}"
 BUNDLE_ID="com.managednebula.client"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DIST_DIR="${SCRIPT_DIR}/dist"
@@ -369,7 +371,7 @@ pkgbuild \
     --root "${PKG_ROOT}" \
     --scripts "${PKG_SCRIPTS}" \
     --identifier "${BUNDLE_ID}" \
-    --version "${VERSION}" \
+    --version "${PKG_VERSION}" \
     --install-location "/" \
     "${PKG_FILE}"
 


### PR DESCRIPTION
## Summary by Sourcery

Streamline the macOS release pipeline by switching the GitHub Actions workflow to trigger on published releases, removing branch-based conditionals, fixing version parsing for beta tags, and consolidating Fastlane match configuration to rely on the CI environment.

Bug Fixes:
- Strip beta suffixes from release tags to ensure correct version numbers for beta releases

Enhancements:
- Use dynamic readonly flags (is_ci) in Fastlane match configurations for both developer_id and installer profiles

CI:
- Trigger macOS release workflow on published release events instead of all pushes
- Set CI environment variable and remove main vs non-main branch checks in the workflow
- Simplify version extraction to derive the version directly from the release tag