### PR TITLE
[bugfix/macos-57] Add error handler and debug output to installer script

### DIFF
--- a/macos_client/create-installer.sh
+++ b/macos_client/create-installer.sh
@@ -3,6 +3,9 @@
 
 set -e
 
+# Add error handler to show which command failed
+trap 'echo "Error on line $LINENO: Command exited with status $?"' ERR
+
 APP_NAME="ManagedNebula"
 # Use VERSION from environment if provided, otherwise default to 1.0.0
 VERSION="${VERSION:-1.0.0}"
@@ -14,6 +17,8 @@ DIST_DIR="${SCRIPT_DIR}/dist"
 NEBULA_VERSION="v1.8.2"
 
 echo "=== ManagedNebula Installer Creator ==="
+echo "VERSION: ${VERSION}"
+echo "PKG_VERSION: ${PKG_VERSION}"
 echo ""
 
 # Clean previous builds


### PR DESCRIPTION
- Add trap for ERR to show which line fails
- Display VERSION and PKG_VERSION at start
- Helps diagnose beta version build failures

## Summary by Sourcery

Improve error diagnostics in the macOS installer script by adding an ERR trap and logging version info on startup

Bug Fixes:
- Add ERR trap to report the line number and exit status when a command fails

Enhancements:
- Print VERSION and PKG_VERSION at the start of the script for debugging