### PR TITLE
[feature/releasebot-0] Fix bash syntax error in auto-rebase workflow

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -38,7 +38,7 @@ jobs:
             
             # Parse YAML and extract branch pairs
             # Format: source_branch: [target_branch1, target_branch2]
-            python3 << 'EOF'
+            python3 << 'EOF' >> "$GITHUB_OUTPUT"
           import yaml
           import json
           import sys
@@ -69,7 +69,10 @@ jobs:
               print(f"Error reading config: {e}", file=sys.stderr)
               print("branches=")
           EOF
-          } >> "$GITHUB_OUTPUT"
+          else
+            echo "Config file not found, skipping rebase"
+            echo "branches=" >> "$GITHUB_OUTPUT"
+          fi
       
       - name: Rebase target branches
         if: steps.config.outputs.branches != ''


### PR DESCRIPTION
Resolves syntax error with orphaned closing brace

- Move output redirection to heredoc line: python3 << 'EOF' >> "$GITHUB_OUTPUT"
- Add else branch for missing config file
- Remove orphaned closing brace that was causing syntax error

## Summary by Sourcery

Fix the auto-rebase GitHub Actions workflow to correctly handle missing config files and avoid bash syntax errors.

Bug Fixes:
- Resolve a bash syntax error in the auto-rebase workflow caused by an orphaned closing brace and misplaced output redirection.
- Ensure the auto-rebase job gracefully handles missing config files by logging a message and emitting an empty branches output.