### PR TITLE
[bugfix/server-102] Fixed faulty alembic migration

### DIFF
--- a/server/alembic/versions/fbea1f1aa652_add_system_settings_and_github_scanning_.py
+++ b/server/alembic/versions/fbea1f1aa652_add_system_settings_and_github_scanning_.py
@@ -1,4 +1,5 @@
-"""add_system_settings_and_github_scanning_tables
+"""
+add_system_settings_and_github_scanning_tables
 
 Revision ID: fbea1f1aa652
 Revises: a108a79483a9


### PR DESCRIPTION
## Summary by Sourcery

Make the Alembic migration for system settings and GitHub secret scanning logs idempotent and safe to rerun.

Bug Fixes:
- Avoid errors when applying the migration on databases where the system_settings or github_secret_scanning_logs tables or the system_settings key index already exist.
- Prevent duplicate default system setting records from being inserted if they are already present.
- Ensure downgrade only drops the affected tables and index if they actually exist.