### PR TITLE
[bugfix/all-129] Add conditional :latest tag on release for pre-release handling

### DIFF
--- a/.github/workflows/push-client.yml
+++ b/.github/workflows/push-client.yml
@@ -107,9 +107,25 @@ jobs:
             --provenance=false \
             --platform linux/amd64,linux/arm64 ./client
 
-      - name: Build and Push Image (tag)
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Build and Push Image (tag - pre-release, version only)
+        if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && github.event.release.prerelease == true
         run: |
+          echo "::notice::Pre-release detected - skipping :latest tag"
+          echo "Building and pushing version tag only: ${GITHUB_REF#refs/tags/}"
+          docker buildx build --push \
+            --build-arg VERSION=${GITHUB_REF#refs/tags/} \
+            --tag harbor.vm.kumpeapps.com/managed-nebula/client:${GITHUB_REF#refs/tags/} \
+            --cache-from type=gha,scope=client-main \
+            --cache-to type=gha,mode=max,scope=client-tag \
+            --cache-from type=registry,ref=harbor.vm.kumpeapps.com/managed-nebula/client:latest \
+            --provenance=false \
+            --platform linux/amd64,linux/arm64 ./client
+
+      - name: Build and Push Image (tag - stable release or manual tag)
+        if: startsWith(github.ref, 'refs/tags/') && (github.event_name != 'release' || github.event.release.prerelease != true)
+        run: |
+          echo "::notice::Stable release or manual tag push - applying both version and :latest tags"
+          echo "Building and pushing tags: ${GITHUB_REF#refs/tags/} and latest"
           docker buildx build --push \
             --build-arg VERSION=${GITHUB_REF#refs/tags/} \
             --tag harbor.vm.kumpeapps.com/managed-nebula/client:${GITHUB_REF#refs/tags/} \

--- a/.github/workflows/push-frontend.yml
+++ b/.github/workflows/push-frontend.yml
@@ -107,9 +107,25 @@ jobs:
             --provenance=false \
             --platform linux/amd64,linux/arm64 ./frontend
 
-      - name: Build and Push Image (tag)
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Build and Push Image (tag - pre-release, version only)
+        if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && github.event.release.prerelease == true
         run: |
+          echo "::notice::Pre-release detected - skipping :latest tag"
+          echo "Building and pushing version tag only: ${GITHUB_REF#refs/tags/}"
+          docker buildx build --push \
+            --build-arg VERSION=${GITHUB_REF#refs/tags/} \
+            --tag harbor.vm.kumpeapps.com/managed-nebula/frontend:${GITHUB_REF#refs/tags/} \
+            --cache-from type=gha,scope=frontend-main \
+            --cache-to type=gha,mode=max,scope=frontend-tag \
+            --cache-from type=registry,ref=harbor.vm.kumpeapps.com/managed-nebula/frontend:latest \
+            --provenance=false \
+            --platform linux/amd64,linux/arm64 ./frontend
+
+      - name: Build and Push Image (tag - stable release or manual tag)
+        if: startsWith(github.ref, 'refs/tags/') && (github.event_name != 'release' || github.event.release.prerelease != true)
+        run: |
+          echo "::notice::Stable release or manual tag push - applying both version and :latest tags"
+          echo "Building and pushing tags: ${GITHUB_REF#refs/tags/} and latest"
           docker buildx build --push \
             --build-arg VERSION=${GITHUB_REF#refs/tags/} \
             --tag harbor.vm.kumpeapps.com/managed-nebula/frontend:${GITHUB_REF#refs/tags/} \

--- a/.github/workflows/push-server.yml
+++ b/.github/workflows/push-server.yml
@@ -107,9 +107,25 @@ jobs:
             --provenance=false \
             --platform linux/amd64,linux/arm64 ./server
 
-      - name: Build and Push Image (tag)
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Build and Push Image (tag - pre-release, version only)
+        if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && github.event.release.prerelease == true
         run: |
+          echo "::notice::Pre-release detected - skipping :latest tag"
+          echo "Building and pushing version tag only: ${GITHUB_REF#refs/tags/}"
+          docker buildx build --push \
+            --build-arg VERSION=${GITHUB_REF#refs/tags/} \
+            --tag harbor.vm.kumpeapps.com/managed-nebula/server:${GITHUB_REF#refs/tags/} \
+            --cache-from type=gha,scope=server-main \
+            --cache-to type=gha,mode=max,scope=server-tag \
+            --cache-from type=registry,ref=harbor.vm.kumpeapps.com/managed-nebula/server:latest \
+            --provenance=false \
+            --platform linux/amd64,linux/arm64 ./server
+
+      - name: Build and Push Image (tag - stable release or manual tag)
+        if: startsWith(github.ref, 'refs/tags/') && (github.event_name != 'release' || github.event.release.prerelease != true)
+        run: |
+          echo "::notice::Stable release or manual tag push - applying both version and :latest tags"
+          echo "Building and pushing tags: ${GITHUB_REF#refs/tags/} and latest"
           docker buildx build --push \
             --build-arg VERSION=${GITHUB_REF#refs/tags/} \
             --tag harbor.vm.kumpeapps.com/managed-nebula/server:${GITHUB_REF#refs/tags/} \


### PR DESCRIPTION
Resolves #129 

- Pre-releases now only push the version tag (e.g., :v1.2.3-beta)
- Stable releases and manual tag pushes push both version and :latest tags
- Added logging to indicate which tags are being pushed
- Updated all three workflow files: push-client.yml, push-server.yml, push-frontend.yml

## Summary by Sourcery

Adjust Docker image push workflows to treat prerelease tags differently from stable and manual tag releases across client, server, and frontend images.

Bug Fixes:
- Prevent prerelease GitHub releases from updating the :latest Docker image tag.

Enhancements:
- Split tag-push steps in client, server, and frontend workflows to distinguish prereleases from stable or manually pushed tags, with clearer logging of which tags are pushed.