### PR TITLE
[bugfix/macos-183] fix macos build error

### DIFF
--- a/macos_client/create-installer.sh
+++ b/macos_client/create-installer.sh
@@ -634,16 +634,6 @@ rm -rf "${PKG_SCRIPTS}"
 rm -rf "${NEBULA_TMP}"
 rm -rf "${DMG_DIR}"
 
-# CRITICAL: Remove app bundles from dist to prevent installer relocation during testing
-# macOS Spotlight indexes these apps and causes the installer to relocate installations
-# The apps are already included in the DMG, so we don't need them loose in dist/
-echo "Removing app bundles from dist (included in DMG)..."
-rm -rf "${DIST_DIR}/${APP_NAME}.app"
-rm -rf "${DIST_DIR}/Uninstall ManagedNebula.app"
-
-echo "✓ Cleanup complete"
-echo ""
-
 # Summary
 echo "=== Build Complete ==="
 echo ""


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent unintended removal of app bundles from the macOS dist directory that caused build or installer issues.