### PR TITLE
[bugfix/client-206] Fix client restart loop due to missing typing import

### DIFF
--- a/client/agent.py
+++ b/client/agent.py
@@ -4,6 +4,7 @@ import time
 import signal
 import hashlib
 from pathlib import Path
+from typing import Optional
 import httpx
 import subprocess
 


### PR DESCRIPTION
Resolves #206

- Add missing 'from typing import Optional' import
- Fixes NameError when _resolve_arch() function is defined
- Client was crashing immediately on startup in v1.5.2

## Summary by Sourcery

Bug Fixes:
- Add the missing Optional type import to prevent NameError in _resolve_arch and stop the client from restarting in a crash loop on startup.