### PR TITLE
[bugfix/server-209] Fix settings cert import path

### DIFF
--- a/server/app/routers/api.py
+++ b/server/app/routers/api.py
@@ -504,7 +504,7 @@ async def update_settings(body: SettingsUpdate, session: AsyncSession = Depends(
         # Additional check: if switching to pure v2 (not hybrid), verify all clients are compatible
         if body.cert_version == 'v2':
             # Query all clients with their nebula_version
-            from ..models.db import Client
+            from ..models.client import Client
             incompatible_clients = []
             result = await session.execute(select(Client))
             clients = result.scalars().all()


### PR DESCRIPTION
Resolves #209

- Import Client model from correct module during cert version validation\n- Prevent settings update from raising ModuleNotFoundError when switching cert versions

## Summary by Sourcery

Bug Fixes:
- Resolve ModuleNotFoundError when validating client compatibility while switching certificate versions in settings.