### PR TITLE
[feature/frontend-214] Set global table width to 95%\n\nResolves #214…

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -127,7 +127,8 @@ textarea:focus {
 
 /* Tables */
 table {
-  width: 100%;
+  width: 95%;
+  margin: 0 auto;
   border-collapse: collapse;
   background: white;
 }


### PR DESCRIPTION
resolves #214

## Summary by Sourcery

Adjust global table styling to reduce width and center tables on the page.

Enhancements:
- Set the default table width to 95% to avoid full-width stretching.
- Center all tables horizontally by applying automatic side margins.