### PR TITLE
[feature/all-230] Update Nebula to v1.10.1

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -130,7 +130,7 @@ jobs:
           
           ## What's Included
           - Native macOS menu bar application
-          - Nebula v1.10.0 binaries (PKG only)
+          - Nebula v1.10.1 binaries (PKG only)
           - Automatic configuration updates
           - Secure Keychain integration
           - LaunchDaemon for auto-start (PKG only)

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,7 +18,7 @@ RUN set -eux; \
             armhf|armel|arm) neb_arch="arm" ;; \
             *) echo "Unsupported architecture: $arch"; exit 1 ;; \
         esac; \
-        NEBULA_VERSION="1.10.0"; \
+        NEBULA_VERSION="1.10.1"; \
         curl -fsSL -o /tmp/nebula.tar.gz \
             "https://github.com/slackhq/nebula/releases/download/v${NEBULA_VERSION}/nebula-linux-${neb_arch}.tar.gz"; \
         tar -C /usr/local/bin -xzvf /tmp/nebula.tar.gz nebula nebula-cert; \

--- a/macos_client/install.sh
+++ b/macos_client/install.sh
@@ -3,8 +3,8 @@
 
 set -e
 
-# Use NEBULA_VERSION from environment if provided, otherwise default to v1.10.0
-NEBULA_VERSION="${NEBULA_VERSION:-v1.10.0}"
+# Use NEBULA_VERSION from environment if provided, otherwise default to v1.10.1
+NEBULA_VERSION="${NEBULA_VERSION:-v1.10.1}"
 NEBULA_URL="https://github.com/slackhq/nebula/releases/download/${NEBULA_VERSION}/nebula-darwin.zip"
 INSTALL_DIR="/usr/local/bin"
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -17,7 +17,7 @@ RUN set -eux; \
             default-libmysqlclient-dev \
             nano \
             rustc cargo; \
-        echo "Installing Nebula v1.10.0 from upstream release (Debian package is outdated)"; \
+        echo "Installing Nebula v1.10.1 from upstream release (Debian package is outdated)"; \
         arch="$(dpkg --print-architecture)"; \
         case "$arch" in \
             amd64) neb_arch="amd64" ;; \
@@ -25,7 +25,7 @@ RUN set -eux; \
             armhf|armel|arm) neb_arch="arm" ;; \
             *) echo "Unsupported architecture: $arch"; exit 1 ;; \
         esac; \
-        NEBULA_VERSION="1.10.0"; \
+        NEBULA_VERSION="1.10.1"; \
         curl -fsSL -o /tmp/nebula.tar.gz "https://github.com/slackhq/nebula/releases/download/v${NEBULA_VERSION}/nebula-linux-${neb_arch}.tar.gz"; \
         tar -C /usr/local/bin -xzvf /tmp/nebula.tar.gz nebula nebula-cert; \
         rm -f /tmp/nebula.tar.gz; \

--- a/windows_client/build-installer.bat
+++ b/windows_client/build-installer.bat
@@ -27,7 +27,7 @@ echo.
 
 REM Configuration
 set "VERSION=1.0.0"
-set "NEBULA_VERSION=1.10.0"
+set "NEBULA_VERSION=1.10.1"
 set "WINTUN_VERSION=0.14.1"
 set "APP_NAME=NebulaAgent"
 set "SCRIPT_DIR=%~dp0"

--- a/windows_client/build.bat
+++ b/windows_client/build.bat
@@ -11,7 +11,7 @@ echo.
 
 REM Configuration
 set "VERSION=1.0.0"
-set "NEBULA_VERSION=1.10.0"
+set "NEBULA_VERSION=1.10.1"
 set "APP_NAME=NebulaAgent"
 set "SCRIPT_DIR=%~dp0"
 set "DIST_DIR=%SCRIPT_DIR%dist"

--- a/windows_client/installer/installer.nsi
+++ b/windows_client/installer/installer.nsi
@@ -39,7 +39,7 @@
 
 ; Nebula version will be set by build script
 !ifndef NEBULA_VERSION
-  !define NEBULA_VERSION "1.10.0"
+  !define NEBULA_VERSION "1.10.1"
 !endif
 
 Name "${PRODUCT_NAME} ${VERSION}"


### PR DESCRIPTION
- Update server/Dockerfile NEBULA_VERSION to 1.10.1
- Update client/Dockerfile NEBULA_VERSION to 1.10.1
- Update macos_client/install.sh default version to v1.10.1
- Update .github/workflows/macos-release.yml release notes
- Update windows_client/build.bat NEBULA_VERSION to 1.10.1
- Update windows_client/build-installer.bat NEBULA_VERSION to 1.10.1
- Update windows_client/installer/installer.nsi NEBULA_VERSION to 1.10.1

## Summary by Sourcery

Bump Nebula dependency to v1.10.1 across server, client, and desktop distribution artifacts.

Build:
- Update server and client Dockerfiles to download and install Nebula v1.10.1.

CI:
- Adjust macOS release workflow notes to reference Nebula v1.10.1 in packaged binaries.

Chores:
- Update macOS installer script and Windows build/installer scripts and metadata to default to Nebula v1.10.1.