### PR TITLE
[feature/all-234] Update Nebula to v1.10.2

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -130,7 +130,7 @@ jobs:
           
           ## What's Included
           - Native macOS menu bar application
-          - Nebula v1.10.1 binaries (PKG only)
+          - Nebula v1.10.2 binaries (PKG only)
           - Automatic configuration updates
           - Secure Keychain integration
           - LaunchDaemon for auto-start (PKG only)

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,7 +18,7 @@ RUN set -eux; \
             armhf|armel|arm) neb_arch="arm" ;; \
             *) echo "Unsupported architecture: $arch"; exit 1 ;; \
         esac; \
-        NEBULA_VERSION="1.10.1"; \
+        NEBULA_VERSION="1.10.2"; \
         curl -fsSL -o /tmp/nebula.tar.gz \
             "https://github.com/slackhq/nebula/releases/download/v${NEBULA_VERSION}/nebula-linux-${neb_arch}.tar.gz"; \
         tar -C /usr/local/bin -xzvf /tmp/nebula.tar.gz nebula nebula-cert; \

--- a/macos_client/install.sh
+++ b/macos_client/install.sh
@@ -3,8 +3,8 @@
 
 set -e
 
-# Use NEBULA_VERSION from environment if provided, otherwise default to v1.10.1
-NEBULA_VERSION="${NEBULA_VERSION:-v1.10.1}"
+# Use NEBULA_VERSION from environment if provided, otherwise default to v1.10.2
+NEBULA_VERSION="${NEBULA_VERSION:-v1.10.2}"
 NEBULA_URL="https://github.com/slackhq/nebula/releases/download/${NEBULA_VERSION}/nebula-darwin.zip"
 INSTALL_DIR="/usr/local/bin"
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -17,15 +17,15 @@ RUN set -eux; \
             default-libmysqlclient-dev \
             nano \
             rustc cargo; \
-        echo "Installing Nebula v1.10.1 from upstream release (Debian package is outdated)"; \
-        arch="$(dpkg --print-architecture)"; \
+        echo "Installing Nebula v1.10.2 from upstream release (Debian package is outdated)";
+        arch="$(dpkg --print-architecture)";
         case "$arch" in \
             amd64) neb_arch="amd64" ;; \
             arm64) neb_arch="arm64" ;; \
             armhf|armel|arm) neb_arch="arm" ;; \
             *) echo "Unsupported architecture: $arch"; exit 1 ;; \
         esac; \
-        NEBULA_VERSION="1.10.1"; \
+        NEBULA_VERSION="1.10.2";
         curl -fsSL -o /tmp/nebula.tar.gz "https://github.com/slackhq/nebula/releases/download/v${NEBULA_VERSION}/nebula-linux-${neb_arch}.tar.gz"; \
         tar -C /usr/local/bin -xzvf /tmp/nebula.tar.gz nebula nebula-cert; \
         rm -f /tmp/nebula.tar.gz; \


### PR DESCRIPTION
Resolves #234

- Update server/Dockerfile: Nebula 1.10.1 → 1.10.2
- Update client/Dockerfile: Nebula 1.10.1 → 1.10.2
- Update macos_client/install.sh: Nebula v1.10.1 → v1.10.2
- Update .github/workflows/macos-release.yml: Documentation reference to v1.10.2

## Summary by Sourcery

Bump Nebula dependency to version 1.10.2 across server, client, and macOS distribution artifacts.

Enhancements:
- Update macOS client installer script default Nebula version to v1.10.2.

Build:
- Update server and client Dockerfiles to download and install Nebula 1.10.2 instead of 1.10.1.

CI:
- Adjust macOS release workflow copy to reference bundled Nebula v1.10.2 binaries.