### PR TITLE
[feature/all-234] fixed

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -19,8 +19,7 @@ RUN set -eux; \
             *) echo "Unsupported architecture: $arch"; exit 1 ;; \
         esac; \
         NEBULA_VERSION="1.10.2"; \
-        curl -fsSL -o /tmp/nebula.tar.gz \
-            "https://github.com/slackhq/nebula/releases/download/v${NEBULA_VERSION}/nebula-linux-${neb_arch}.tar.gz"; \
+        curl -fsSL -o /tmp/nebula.tar.gz "https://github.com/slackhq/nebula/releases/download/v${NEBULA_VERSION}/nebula-linux-${neb_arch}.tar.gz"; \
         tar -C /usr/local/bin -xzvf /tmp/nebula.tar.gz nebula nebula-cert; \
         rm -f /tmp/nebula.tar.gz; \
         rm -rf /var/lib/apt/lists/*

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -25,7 +25,7 @@ RUN set -eux; \
             armhf|armel|arm) neb_arch="arm" ;; \
             *) echo "Unsupported architecture: $arch"; exit 1 ;; \
         esac; \
-        NEBULA_VERSION="1.10.2";
+        NEBULA_VERSION="1.10.2"; \
         curl -fsSL -o /tmp/nebula.tar.gz "https://github.com/slackhq/nebula/releases/download/v${NEBULA_VERSION}/nebula-linux-${neb_arch}.tar.gz"; \
         tar -C /usr/local/bin -xzvf /tmp/nebula.tar.gz nebula nebula-cert; \
         rm -f /tmp/nebula.tar.gz; \


### PR DESCRIPTION
## Summary by Sourcery

Update Nebula dependency to version 1.10.2 across server, client, macOS installer, and related release workflow metadata.

Enhancements:
- Align Nebula version usage across Docker images and macOS installer script to 1.10.2.
- Refresh macOS release workflow notes to reflect the updated bundled Nebula version.