### PR TITLE
[feature/all-234] fixed

### DIFF
--- a/.github/workflows/push-client.yml
+++ b/.github/workflows/push-client.yml
@@ -81,10 +81,19 @@ jobs:
             BRANCH_NAME="${GITHUB_REF#refs/heads/}"
             echo "Current branch: ${BRANCH_NAME}"
             
-            LATEST_RELEASE=$(curl -s https://api.github.com/repos/kumpeapps/managed-nebula/releases | \
-              jq -r --arg branch "$BRANCH_NAME" '[
+            # Fetch releases with error handling
+            RELEASES_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/kumpeapps/managed-nebula/releases)
+            
+            # Check if we got valid JSON
+            if echo "$RELEASES_JSON" | jq -e . >/dev/null 2>&1; then
+              LATEST_RELEASE=$(echo "$RELEASES_JSON" | jq -r --arg branch "$BRANCH_NAME" '[
                 .[] | select(.target_commitish == $branch or .target_commitish == "main")
               ] | .[0].tag_name // "v1.0.0"')
+            else
+              echo "Warning: Failed to fetch releases from GitHub API, using default version"
+              LATEST_RELEASE="v1.0.0"
+            fi
             
             echo "Latest release version for ${BRANCH_NAME}: ${LATEST_RELEASE}"
           fi

--- a/.github/workflows/push-frontend.yml
+++ b/.github/workflows/push-frontend.yml
@@ -81,10 +81,19 @@ jobs:
             BRANCH_NAME="${GITHUB_REF#refs/heads/}"
             echo "Current branch: ${BRANCH_NAME}"
             
-            LATEST_RELEASE=$(curl -s https://api.github.com/repos/kumpeapps/managed-nebula/releases | \
-              jq -r --arg branch "$BRANCH_NAME" '[
+            # Fetch releases with error handling
+            RELEASES_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/kumpeapps/managed-nebula/releases)
+            
+            # Check if we got valid JSON
+            if echo "$RELEASES_JSON" | jq -e . >/dev/null 2>&1; then
+              LATEST_RELEASE=$(echo "$RELEASES_JSON" | jq -r --arg branch "$BRANCH_NAME" '[
                 .[] | select(.target_commitish == $branch or .target_commitish == "main")
               ] | .[0].tag_name // "v1.0.0"')
+            else
+              echo "Warning: Failed to fetch releases from GitHub API, using default version"
+              LATEST_RELEASE="v1.0.0"
+            fi
             
             echo "Latest release version for ${BRANCH_NAME}: ${LATEST_RELEASE}"
           fi

--- a/.github/workflows/push-server.yml
+++ b/.github/workflows/push-server.yml
@@ -81,10 +81,19 @@ jobs:
             BRANCH_NAME="${GITHUB_REF#refs/heads/}"
             echo "Current branch: ${BRANCH_NAME}"
             
-            LATEST_RELEASE=$(curl -s https://api.github.com/repos/kumpeapps/managed-nebula/releases | \
-              jq -r --arg branch "$BRANCH_NAME" '[
+            # Fetch releases with error handling
+            RELEASES_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/kumpeapps/managed-nebula/releases)
+            
+            # Check if we got valid JSON
+            if echo "$RELEASES_JSON" | jq -e . >/dev/null 2>&1; then
+              LATEST_RELEASE=$(echo "$RELEASES_JSON" | jq -r --arg branch "$BRANCH_NAME" '[
                 .[] | select(.target_commitish == $branch or .target_commitish == "main")
               ] | .[0].tag_name // "v1.0.0"')
+            else
+              echo "Warning: Failed to fetch releases from GitHub API, using default version"
+              LATEST_RELEASE="v1.0.0"
+            fi
             
             echo "Latest release version for ${BRANCH_NAME}: ${LATEST_RELEASE}"
           fi


### PR DESCRIPTION
## Summary by Sourcery

Improve GitHub workflow robustness when resolving the latest release version and tidy Nebula download steps in Dockerfiles.

Build:
- Update push workflows to authenticate GitHub API release queries, validate JSON responses, and fall back to a default version when release data cannot be fetched.
- Adjust client and server Dockerfiles to clean up Nebula download RUN commands and fix shell line continuation for the Nebula version assignment.