### PR TITLE
[feature/all-234] Fix line continuation in server Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -17,8 +17,8 @@ RUN set -eux; \
             default-libmysqlclient-dev \
             nano \
             rustc cargo; \
-        echo "Installing Nebula v1.10.2 from upstream release (Debian package is outdated)";
-        arch="$(dpkg --print-architecture)";
+        echo "Installing Nebula v1.10.2 from upstream release (Debian package is outdated)"; \
+        arch="$(dpkg --print-architecture)"; \
         case "$arch" in \
             amd64) neb_arch="amd64" ;; \
             arm64) neb_arch="arm64" ;; \


### PR DESCRIPTION
Resolves #234

- Add missing backslashes after echo and arch assignment
- Ensures proper RUN command continuation for multi-platform builds