### PR TITLE
[bugfix/all-251] Added nebula Version update via frontend config

### DIFF
--- a/.GIT_QUICKOPS_CONFIG
+++ b/.GIT_QUICKOPS_CONFIG
@@ -1,0 +1,4 @@
+{
+  "commitPrefix": "[{{branch}}] ",
+  "requireTests": "disabled"
+}

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,7 +18,7 @@ RUN set -eux; \
             armhf|armel|arm) neb_arch="arm" ;; \
             *) echo "Unsupported architecture: $arch"; exit 1 ;; \
         esac; \
-        NEBULA_VERSION="1.10.0"; \
+        NEBULA_VERSION="1.10.3"; \
         curl -fsSL -o /tmp/nebula.tar.gz \
             "https://github.com/slackhq/nebula/releases/download/v${NEBULA_VERSION}/nebula-linux-${neb_arch}.tar.gz"; \
         tar -C /usr/local/bin -xzvf /tmp/nebula.tar.gz nebula nebula-cert; \

--- a/frontend/src/app/models/index.ts
+++ b/frontend/src/app/models/index.ts
@@ -256,6 +256,20 @@ export interface NebulaVersionsResponse {
   versions: NebulaVersionInfo[];  // Alias for available_versions
 }
 
+export interface NebulaInstallationStatus {
+  installed_version: string | null;
+  configured_version: string;
+  is_up_to_date: boolean;
+  message: string;
+}
+
+export interface NebulaInstallationResponse {
+  success: boolean;
+  message: string;
+  installed_version: string | null;
+  previous_version: string | null;
+}
+
 export interface DockerComposeTemplate {
   template: string;
 }

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
-import { Client, Group, FirewallRuleset, IPPool, IPGroup, AvailableIP, CACertificate, User, ClientUpdateRequest, ClientCreateRequest, ClientCertificate, ClientConfigDownload, Settings, SettingsUpdate, DockerComposeTemplate, PlaceholdersResponse, Permission, VersionResponse, VersionStatusResponse, NebulaVersionsResponse } from '../models';
+import { Client, Group, FirewallRuleset, IPPool, IPGroup, AvailableIP, CACertificate, User, ClientUpdateRequest, ClientCreateRequest, ClientCertificate, ClientConfigDownload, Settings, SettingsUpdate, DockerComposeTemplate, PlaceholdersResponse, Permission, VersionResponse, VersionStatusResponse, NebulaVersionsResponse, NebulaInstallationStatus, NebulaInstallationResponse } from '../models';
 
 @Injectable({
   providedIn: 'root'
@@ -322,6 +322,14 @@ export class ApiService {
   // Nebula version management endpoints
   getNebulaVersions(): Observable<NebulaVersionsResponse> {
     return this.applyDelay(this.http.get<NebulaVersionsResponse>(`${this.apiUrl}/nebula/versions`, { withCredentials: true }));
+  }
+
+  getNebulaInstallationStatus(): Observable<NebulaInstallationStatus> {
+    return this.applyDelay(this.http.get<NebulaInstallationStatus>(`${this.apiUrl}/nebula/installation-status`, { withCredentials: true }));
+  }
+
+  installNebulaVersion(): Observable<NebulaInstallationResponse> {
+    return this.applyDelay(this.http.post<NebulaInstallationResponse>(`${this.apiUrl}/nebula/install`, {}, { withCredentials: true }));
   }
 
   getVersionCacheStatus(): Observable<any> {

--- a/macos_client/create-installer.sh
+++ b/macos_client/create-installer.sh
@@ -14,8 +14,8 @@ PKG_VERSION="${VERSION%%-*}"
 BUNDLE_ID="com.managednebula.client"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DIST_DIR="${SCRIPT_DIR}/dist"
-# Use NEBULA_VERSION from environment if provided, otherwise default to v1.10.0
-NEBULA_VERSION="${NEBULA_VERSION:-v1.10.0}"
+# Use NEBULA_VERSION from environment if provided, otherwise default to v1.10.3
+NEBULA_VERSION="${NEBULA_VERSION:-v1.10.3}"
 
 echo "=== ManagedNebula Installer Creator ==="
 echo "VERSION: ${VERSION}"

--- a/macos_client/install.sh
+++ b/macos_client/install.sh
@@ -3,8 +3,8 @@
 
 set -e
 
-# Use NEBULA_VERSION from environment if provided, otherwise default to v1.10.0
-NEBULA_VERSION="${NEBULA_VERSION:-v1.10.0}"
+# Use NEBULA_VERSION from environment if provided, otherwise default to v1.10.3
+NEBULA_VERSION="${NEBULA_VERSION:-v1.10.3}"
 NEBULA_URL="https://github.com/slackhq/nebula/releases/download/${NEBULA_VERSION}/nebula-darwin.zip"
 INSTALL_DIR="/usr/local/bin"
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -17,7 +17,7 @@ RUN set -eux; \
             default-libmysqlclient-dev \
             nano \
             rustc cargo; \
-        echo "Installing Nebula v1.10.0 from upstream release (Debian package is outdated)"; \
+        echo "Installing Nebula v1.10.3 from upstream release (Debian package is outdated)"; \
         arch="$(dpkg --print-architecture)"; \
         case "$arch" in \
             amd64) neb_arch="amd64" ;; \
@@ -25,7 +25,7 @@ RUN set -eux; \
             armhf|armel|arm) neb_arch="arm" ;; \
             *) echo "Unsupported architecture: $arch"; exit 1 ;; \
         esac; \
-        NEBULA_VERSION="1.10.0"; \
+        NEBULA_VERSION="1.10.3"; \
         curl -fsSL -o /tmp/nebula.tar.gz "https://github.com/slackhq/nebula/releases/download/v${NEBULA_VERSION}/nebula-linux-${neb_arch}.tar.gz"; \
         tar -C /usr/local/bin -xzvf /tmp/nebula.tar.gz nebula nebula-cert; \
         rm -f /tmp/nebula.tar.gz; \

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -28,4 +28,7 @@ class Settings(BaseModel):
     github_token: str = os.getenv("GITHUB_TOKEN", "")
 
 
+# Default Nebula version used across the application
+DEFAULT_NEBULA_VERSION = "1.10.3"
+
 settings = Settings()

--- a/server/app/models/schemas.py
+++ b/server/app/models/schemas.py
@@ -399,6 +399,22 @@ class VersionCacheResponse(BaseModel):
     cache_age_hours: Optional[float] = None
 
 
+class NebulaInstallationStatusResponse(BaseModel):
+    """Response model for Nebula installation status."""
+    installed_version: Optional[str] = None
+    configured_version: str
+    is_up_to_date: bool
+    message: str
+
+
+class NebulaInstallationResponse(BaseModel):
+    """Response model for Nebula installation operation."""
+    success: bool
+    message: str
+    installed_version: Optional[str] = None
+    previous_version: Optional[str] = None
+
+
 # ============ User Schemas ============
 
 class UserCreate(BaseModel):
@@ -473,7 +489,7 @@ class SettingsResponse(BaseModel):
     docker_compose_template: str
     externally_managed_users: bool
     cert_version: str = "v1"  # v1, v2, or hybrid
-    nebula_version: str = "1.9.7"  # Nebula binary version
+    nebula_version: str = "1.10.3"  # Nebula binary version
     v2_support_available: bool = False  # Computed: True if nebula_version >= 1.10.0
 
 class SettingsUpdate(BaseModel):
@@ -483,6 +499,7 @@ class SettingsUpdate(BaseModel):
     docker_compose_template: Optional[str] = None
     cert_version: Optional[str] = None  # v1, v2, or hybrid
     nebula_version: Optional[str] = None  # Nebula binary version
+    auto_install_nebula: Optional[bool] = True  # Auto-install Nebula when version changes
 
 
 class DockerComposeTemplateResponse(BaseModel):

--- a/server/app/models/settings.py
+++ b/server/app/models/settings.py
@@ -1,6 +1,7 @@
 from sqlalchemy import String, Integer, Boolean, Text
 from sqlalchemy.orm import Mapped, mapped_column
 from ..db import Base
+from ..core.config import DEFAULT_NEBULA_VERSION
 
 
 # Default docker-compose template with placeholders
@@ -42,5 +43,5 @@ class GlobalSettings(Base):
     docker_compose_template: Mapped[str] = mapped_column(Text, default=DEFAULT_DOCKER_COMPOSE_TEMPLATE)
     # Certificate version: v1 (default), v2, or hybrid (v2 requires Nebula 1.10.0+)
     cert_version: Mapped[str] = mapped_column(String(20), default="v1")
-    # Nebula binary version (default: 1.9.7, supports 1.10.0+ for v2 certs)
-    nebula_version: Mapped[str] = mapped_column(String(50), default="1.9.7")
+    # Nebula binary version (supports 1.10.0+ for v2 certs)
+    nebula_version: Mapped[str] = mapped_column(String(50), default=DEFAULT_NEBULA_VERSION)

--- a/server/app/services/nebula_installer.py
+++ b/server/app/services/nebula_installer.py
@@ -1,0 +1,292 @@
+"""
+Nebula Binary Installer Service
+
+Downloads and installs Nebula binaries (nebula and nebula-cert) from GitHub releases.
+Supports automatic version management based on GlobalSettings.nebula_version.
+"""
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Installation paths
+NEBULA_BIN_PATH = Path("/usr/local/bin/nebula")
+NEBULA_CERT_BIN_PATH = Path("/usr/local/bin/nebula-cert")
+
+
+class NebulaInstaller:
+    """Service for installing and managing Nebula binaries on the server."""
+    
+    def __init__(self):
+        """Initialize the Nebula installer service."""
+        self.github_repo = "slackhq/nebula"
+        self.base_url = "https://github.com"
+    
+    def get_installed_version(self) -> Optional[str]:
+        """
+        Get the currently installed Nebula version.
+        
+        Returns:
+            Version string (e.g., "1.10.0") or None if not installed
+        """
+        if not NEBULA_BIN_PATH.exists():
+            logger.info("Nebula binary not found at %s (may be first install)", NEBULA_BIN_PATH)
+            return None
+        
+        try:
+            # Security Note: NEBULA_BIN_PATH is a controlled constant (/usr/local/bin/nebula),
+            # not user input. This is safe from command injection.
+            result = subprocess.run(
+                [str(NEBULA_BIN_PATH), "-version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=True
+            )
+            
+            # Parse version from output like "Nebula version 1.9.7"
+            for line in result.stdout.splitlines():
+                if "version" in line.lower():
+                    parts = line.split()
+                    for i, part in enumerate(parts):
+                        if part.lower() == "version" and i + 1 < len(parts):
+                            version = parts[i + 1].lstrip('v')
+                            logger.info("Detected installed Nebula version: %s", version)
+                            return version
+            
+            logger.warning("Could not parse version from nebula -version output")
+            return None
+            
+        except subprocess.TimeoutExpired:
+            logger.error("Timeout running nebula -version")
+            return None
+        except subprocess.CalledProcessError as e:
+            logger.error("Failed to get nebula version: %s", e)
+            return None
+        except Exception as e:
+            logger.error("Unexpected error getting nebula version: %s", e)
+            return None
+    
+    def _detect_architecture(self) -> Optional[str]:
+        """
+        Detect the system architecture for downloading the correct binary.
+        
+        Returns:
+            Architecture string for Nebula downloads (e.g., "amd64", "arm64", "arm")
+            or None if unsupported
+        """
+        machine = platform.machine().lower()
+        
+        arch_map = {
+            'x86_64': 'amd64',
+            'amd64': 'amd64',
+            'aarch64': 'arm64',
+            'arm64': 'arm64',
+            'armv7l': 'arm',
+            'armhf': 'arm',
+        }
+        
+        nebula_arch = arch_map.get(machine)
+        if not nebula_arch:
+            logger.error("Unsupported architecture: %s", machine)
+            return None
+        
+        logger.info("Detected architecture: %s (Nebula: %s)", machine, nebula_arch)
+        return nebula_arch
+    
+    async def download_and_install(self, version: str, force: bool = False) -> Tuple[bool, str]:
+        """
+        Download and install a specific Nebula version.
+        
+        Args:
+            version: Version string (e.g., "1.10.0") without 'v' prefix
+            force: Force installation even if version is already installed
+            
+        Returns:
+            Tuple of (success: bool, message: str)
+        """
+        # Normalize version (remove 'v' prefix if present)
+        version = version.lstrip('v')
+        
+        # Check if already installed
+        if not force:
+            installed_version = self.get_installed_version()
+            if installed_version == version:
+                msg = f"Nebula {version} is already installed"
+                logger.info(msg)
+                return True, msg
+        
+        # Detect architecture
+        arch = self._detect_architecture()
+        if not arch:
+            return False, "Unsupported system architecture"
+        
+        # Construct download URL
+        download_url = (
+            f"{self.base_url}/{self.github_repo}/releases/download/"
+            f"v{version}/nebula-linux-{arch}.tar.gz"
+        )
+        
+        logger.info("Downloading Nebula %s from %s", version, download_url)
+        
+        try:
+            # Download to temporary directory
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tmpdir_path = Path(tmpdir)
+                tar_path = tmpdir_path / "nebula.tar.gz"
+                
+                # Download with timeout
+                async with httpx.AsyncClient(timeout=120.0, follow_redirects=True) as client:
+                    async with client.stream("GET", download_url) as response:
+                        if response.status_code == 404:
+                            msg = f"Nebula version {version} not found for architecture {arch}"
+                            logger.error(msg)
+                            return False, msg
+                        
+                        response.raise_for_status()
+                        
+                        # Stream download to file
+                        with open(tar_path, 'wb') as f:
+                            async for chunk in response.aiter_bytes(chunk_size=8192):
+                                f.write(chunk)
+                
+                logger.info("Download complete, extracting...")
+                
+                # Extract tar.gz with path traversal protection
+                with tarfile.open(tar_path, 'r:gz') as tar:
+                    # Verify all members are safe before extraction
+                    for member in tar.getmembers():
+                        member_path = (tmpdir_path / member.name).resolve()
+                        if not str(member_path).startswith(str(tmpdir_path.resolve())):
+                            msg = f"Unsafe path in archive: {member.name}"
+                            logger.error(msg)
+                            return False, msg
+                    # Safe to extract after validation
+                    tar.extractall(tmpdir_path)
+                
+                # Verify binaries exist
+                nebula_tmp = tmpdir_path / "nebula"
+                nebula_cert_tmp = tmpdir_path / "nebula-cert"
+                
+                if not nebula_tmp.exists():
+                    msg = "nebula binary not found in downloaded archive"
+                    logger.error(msg)
+                    return False, msg
+                
+                if not nebula_cert_tmp.exists():
+                    msg = "nebula-cert binary not found in downloaded archive"
+                    logger.error(msg)
+                    return False, msg
+                
+                # Verify downloaded version
+                # Security Note: nebula_tmp is a Path we created in our controlled tmpdir,
+                # not derived from user input. This is safe from command injection.
+                result = subprocess.run(
+                    [str(nebula_tmp), "-version"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    check=True
+                )
+                
+                downloaded_version = None
+                for line in result.stdout.splitlines():
+                    if "version" in line.lower():
+                        parts = line.split()
+                        for i, part in enumerate(parts):
+                            if part.lower() == "version" and i + 1 < len(parts):
+                                downloaded_version = parts[i + 1].lstrip('v')
+                                break
+                
+                if downloaded_version != version:
+                    msg = f"Version mismatch: expected {version}, got {downloaded_version}"
+                    logger.error(msg)
+                    return False, msg
+                
+                logger.info("Verified downloaded Nebula version: %s", downloaded_version)
+                
+                # Backup existing binaries if they exist
+                if NEBULA_BIN_PATH.exists():
+                    backup_path = NEBULA_BIN_PATH.parent / f"nebula.backup.{int(os.path.getmtime(NEBULA_BIN_PATH))}"
+                    shutil.copy2(NEBULA_BIN_PATH, backup_path)
+                    logger.info("Backed up old nebula to %s", backup_path)
+                
+                if NEBULA_CERT_BIN_PATH.exists():
+                    backup_path = NEBULA_CERT_BIN_PATH.parent / f"nebula-cert.backup.{int(os.path.getmtime(NEBULA_CERT_BIN_PATH))}"
+                    shutil.copy2(NEBULA_CERT_BIN_PATH, backup_path)
+                    logger.info("Backed up old nebula-cert to %s", backup_path)
+                
+                # Install new binaries
+                shutil.copy2(nebula_tmp, NEBULA_BIN_PATH)
+                shutil.copy2(nebula_cert_tmp, NEBULA_CERT_BIN_PATH)
+                
+                # Set executable permissions
+                NEBULA_BIN_PATH.chmod(0o755)
+                NEBULA_CERT_BIN_PATH.chmod(0o755)
+                
+                logger.info("Successfully installed Nebula %s", version)
+                
+                # Verify final installation
+                final_version = self.get_installed_version()
+                if final_version != version:
+                    msg = f"Installation verification failed: expected {version}, got {final_version}"
+                    logger.error(msg)
+                    return False, msg
+                
+                msg = f"Successfully installed Nebula {version}"
+                return True, msg
+                
+        except httpx.HTTPError as e:
+            msg = f"Download failed: {str(e)}"
+            logger.error(msg)
+            return False, msg
+        except tarfile.TarError as e:
+            msg = f"Failed to extract archive: {str(e)}"
+            logger.error(msg)
+            return False, msg
+        except subprocess.CalledProcessError as e:
+            msg = f"Failed to verify binary: {str(e)}"
+            logger.error(msg)
+            return False, msg
+        except Exception as e:
+            msg = f"Unexpected error during installation: {str(e)}"
+            logger.error(msg, exc_info=True)
+            return False, msg
+    
+    async def ensure_version_installed(self, desired_version: str) -> Tuple[bool, str]:
+        """
+        Ensure the desired Nebula version is installed, installing if necessary.
+        
+        Args:
+            desired_version: Desired version string (e.g., "1.10.0")
+            
+        Returns:
+            Tuple of (success: bool, message: str)
+        """
+        desired_version = desired_version.lstrip('v')
+        installed_version = self.get_installed_version()
+        
+        if installed_version is None:
+            logger.info("Nebula not installed, installing version %s", desired_version)
+            return await self.download_and_install(desired_version)
+        
+        if installed_version == desired_version:
+            msg = f"Nebula {desired_version} is already installed"
+            logger.info(msg)
+            return True, msg
+        
+        logger.info(
+            "Nebula version mismatch: installed=%s, desired=%s. Upgrading...",
+            installed_version,
+            desired_version
+        )
+        return await self.download_and_install(desired_version, force=True)

--- a/windows_client/build-installer.bat
+++ b/windows_client/build-installer.bat
@@ -27,7 +27,7 @@ echo.
 
 REM Configuration
 set "VERSION=1.0.0"
-set "NEBULA_VERSION=1.10.0"
+set "NEBULA_VERSION=1.10.3"
 set "WINTUN_VERSION=0.14.1"
 set "APP_NAME=NebulaAgent"
 set "SCRIPT_DIR=%~dp0"

--- a/windows_client/build.bat
+++ b/windows_client/build.bat
@@ -11,7 +11,7 @@ echo.
 
 REM Configuration
 set "VERSION=1.0.0"
-set "NEBULA_VERSION=1.10.0"
+set "NEBULA_VERSION=1.10.3"
 set "APP_NAME=NebulaAgent"
 set "SCRIPT_DIR=%~dp0"
 set "DIST_DIR=%SCRIPT_DIR%dist"

--- a/windows_client/installer/installer.nsi
+++ b/windows_client/installer/installer.nsi
@@ -39,7 +39,7 @@
 
 ; Nebula version will be set by build script
 !ifndef NEBULA_VERSION
-  !define NEBULA_VERSION "1.10.0"
+  !define NEBULA_VERSION "1.10.3"
 !endif
 
 Name "${PRODUCT_NAME} ${VERSION}"


### PR DESCRIPTION
## Summary by Sourcery

Add server-managed Nebula binary installation and version management with frontend visibility and controls, while updating the default Nebula version across the stack.

New Features:
- Expose Nebula server installation status and manual install/update trigger in the settings UI.
- Provide API endpoints to query Nebula installation status and to install or update the server Nebula binaries to the configured version.
- Automatically ensure the configured Nebula version is installed on server startup and when settings change, with optional auto-install behavior.

Enhancements:
- Centralize the default Nebula version configuration and update all components to use Nebula 1.10.3 by default.
- Introduce a reusable NebulaInstaller service to handle downloading, verifying, backing up, and installing Nebula binaries on the server.

Build:
- Update Dockerfiles and client installer scripts to use Nebula 1.10.3 for bundled binaries.