### PR TITLE
Feature/268

### DIFF
--- a/.github/workflows/push-client.yml
+++ b/.github/workflows/push-client.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: Set up QEMU (multi-arch emulation)
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/push-frontend.yml
+++ b/.github/workflows/push-frontend.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: Get Latest Release Version
         id: get_version
         run: |

--- a/.github/workflows/push-server.yml
+++ b/.github/workflows/push-server.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: Set up QEMU (multi-arch emulation)
         uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
## Summary by Sourcery

Migrate container image build and publish workflows from Harbor to GitHub Container Registry for frontend, client, and server components, while preserving multi-arch builds and release tagging behavior.

Enhancements:
- Refine release tagging logic to handle pre-release versus stable tags while supporting :latest and dev-latest tags for images.
- Improve Dockerfile version substitution commands to handle version strings containing forward slashes safely.

Build:
- Update GitHub Actions workflows to build and push frontend, client, and server images to ghcr.io instead of Harbor, using docker/build-push-action and GitHub-hosted runners.
- Configure registry, image naming, permissions, and caching for multi-architecture builds across dev, main, and tagged releases in all push workflows.

<!-- kumpeapps-issue-autoclose -->
Closes #268