### PR TITLE
[feature/268] Fix workflow runner - use ubuntu-latest for all services

### DIFF
--- a/.github/workflows/push-client.yml
+++ b/.github/workflows/push-client.yml
@@ -40,7 +40,7 @@ jobs:
         )
       )
     timeout-minutes: 120
-    runs-on: vm-prod-github-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6

--- a/.github/workflows/push-server.yml
+++ b/.github/workflows/push-server.yml
@@ -40,7 +40,7 @@ jobs:
         )
       )
     timeout-minutes: 120
-    runs-on: vm-prod-github-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6


### PR DESCRIPTION
Resolves #268

- Changed server and client workflows from vm-prod-github-runner to ubuntu-latest
- GitHub hosted runners have passwordless sudo for jq installation
- All three services now consistently use GitHub hosted runners
- This fixes the 'sudo: a password is required' error

## Summary by Sourcery

Update CI workflows to run client and server jobs on GitHub-hosted ubuntu-latest runners instead of a self-hosted runner.

CI:
- Switch client workflow runner from vm-prod-github-runner to ubuntu-latest.
- Switch server workflow runner from vm-prod-github-runner to ubuntu-latest.