### PR TITLE
[bug/286] Resolved macos package ruby issues

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
         bundler-cache: true
         working-directory: macos_client
     


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump Ruby version from 3.1 to 3.2 in the macOS release GitHub Actions workflow for the macos_client directory.

<!-- kumpeapps-issue-autoclose -->
Closes #286