### PR TITLE
[feature/#318] Added client certificate revocation in bulk

### DIFF
--- a/.github/agents/managed-nebula-integration.agent.md
+++ b/.github/agents/managed-nebula-integration.agent.md
@@ -529,7 +529,8 @@ All endpoints use `/api/v1` prefix unless otherwise noted. Most endpoints requir
 - `GET /api/v1/clients/{id}/config` - Download Nebula config YAML (includes revocation list)
 - `GET /api/v1/clients/{id}/docker-compose` - Generate Docker Compose file
 - `POST /api/v1/clients/{id}/certificates/reissue` - Force certificate rotation
-- `POST /api/v1/clients/{id}/certificates/{cert_id}/revoke` - **NEW**: Revoke specific certificate with optional replacement
+- `POST /api/v1/clients/{id}/certificates/revoke` - **NEW**: Revoke ALL active certificates with optional replacement
+- `POST /api/v1/clients/{id}/certificates/{cert_id}/revoke` - **NEW**: Revoke specific certificate by ID
 - `GET /api/v1/clients/{id}/certificates` - **NEW**: List all certificates including revocation status
 - `POST /api/v1/clients/{id}/token/reissue` - Rotate client token (auto-detects active token)
 - `POST /api/v1/clients/{id}/tokens/{token_id}/reissue` - Rotate specific client token
@@ -639,10 +640,13 @@ All endpoints use `/api/v1` prefix unless otherwise noted. Most endpoints requir
 
 #### API Endpoints
 
-- `POST /api/v1/clients/{id}/certificates/revoke` - Manually revoke a client's current certificate
+- `POST /api/v1/clients/{id}/certificates/revoke` - Revoke ALL active certificates for a client
   - Request body: `{"reason": "compromised", "issue_new": true}`
   - `issue_new=true`: Automatically issues new certificate after revocation
   - `issue_new=false`: Only revokes, no replacement (client will lose connectivity)
+  - Returns count of revoked certificates and their fingerprints
+- `POST /api/v1/clients/{id}/certificates/{cert_id}/revoke` - Revoke a specific certificate by ID
+  - For targeted revocation of a single certificate
 - `GET /api/v1/clients/{id}/certificates` - List all certificates for a client (including revoked)
 - **Automatic on DELETE**: Deleting a client (`DELETE /api/v1/clients/{id}`) automatically adds all its certificates to revocation list
 
@@ -665,10 +669,10 @@ grace_cutoff = utcnow() - timedelta(days=30)
 
 #### Integration Examples
 
-**Manual Revocation with Replacement:**
+**Manual Bulk Revocation with Replacement:**
 ```python
-def revoke_and_reissue(api_url, api_key, client_id):
-    """Revoke current certificate and issue a new one."""
+def revoke_all_and_reissue(api_url, api_key, client_id):
+    """Revoke ALL active certificates and issue a new one."""
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json"
@@ -684,7 +688,27 @@ def revoke_and_reissue(api_url, api_key, client_id):
     )
     response.raise_for_status()
     
-    # New certificate automatically issued and included in response
+    result = response.json()
+    # Response includes count and fingerprints of revoked certificates
+    print(f"Revoked {result['revoked_count']} certificates")
+    print(f"New certificate issued: {result['new_certificate_issued']}")
+    return result
+```
+
+**Revoke Specific Certificate:**
+```python
+def revoke_specific_cert(api_url, api_key, client_id, cert_id):
+    """Revoke a specific certificate by ID."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json"
+    }
+    
+    response = requests.post(
+        f"{api_url}/api/v1/clients/{client_id}/certificates/{cert_id}/revoke",
+        headers=headers
+    )
+    response.raise_for_status()
     return response.json()
 ```
 
@@ -793,7 +817,8 @@ Migration automatically imports existing revoked certificates from `client_certi
 5. **Store Keys Securely**: Use environment variables or secret managers
 6. **Monitor Key Usage**: Check last_used_at and usage_count regularly
 7. **Revoke Compromised Certificates**: Use certificate revocation API to immediately block compromised certificates:
-   - Manual revocation: `POST /api/v1/clients/{id}/certificates/revoke` with `issue_new: true`
+   - Manual bulk revocation: `POST /api/v1/clients/{id}/certificates/revoke` with `issue_new: true` (revokes ALL active certs)
+   - Specific certificate revocation: `POST /api/v1/clients/{id}/certificates/{cert_id}/revoke`
    - Automatic revocation: Deleting a client automatically revokes all its certificates
    - Persistent blocklist: Revoked certificates remain blocked even after client deletion
 8. **GitHub Secret Scanning**: Managed Nebula supports automatic token revocation if keys are leaked to public GitHub repos
@@ -972,7 +997,8 @@ class ManagedNebulaConfig:
 
 ### Issue: Revoked certificate still working/Need to revoke a certificate
 **Solution**: 
-- **Manual Revocation**: Use `POST /api/v1/clients/{id}/certificates/revoke` with `issue_new: true` to revoke and replace
+- **Manual Bulk Revocation**: Use `POST /api/v1/clients/{id}/certificates/revoke` with `issue_new: true` to revoke ALL active certificates and replace
+- **Specific Certificate Revocation**: Use `POST /api/v1/clients/{id}/certificates/{cert_id}/revoke` to revoke a single certificate
 - **Automatic Revocation**: Client deletion automatically revokes all certificates permanently
 - **Grace Period**: Revoked certs stay in blocklist for 30 days after expiration for time-sync tolerance
 - **Reuse Prevention**: Revoked certificates persist in database even after client deletion

--- a/server/app/models/schemas.py
+++ b/server/app/models/schemas.py
@@ -478,6 +478,21 @@ class ClientConfigDownloadResponse(BaseModel):
     ca_chain_pems: List[str]
 
 
+class ClientCertificateRevokeRequest(BaseModel):
+    """Request model for revoking client certificates."""
+    reason: Optional[str] = "manual_revocation"
+    issue_new: bool = False  # Whether to issue a new certificate after revocation
+
+
+class ClientCertificateRevokeResponse(BaseModel):
+    """Response model for certificate revocation."""
+    status: str
+    revoked_count: int
+    revoked_fingerprints: List[str]
+    message: str
+    new_certificate_issued: bool = False
+
+
 # ============ Client Agent Schema ============
 
 class ClientConfigRequest(BaseModel):

--- a/server/app/routers/api.py
+++ b/server/app/routers/api.py
@@ -88,6 +88,8 @@ from ..models.schemas import (
     APIKeyCreateResponse,
     APIKeyUpdate,
     APIKeyListResponse,
+    ClientCertificateRevokeRequest,
+    ClientCertificateRevokeResponse,
 )
 from ..services.cert_manager import CertManager
 from ..services.config_builder import build_nebula_config
@@ -2253,6 +2255,271 @@ async def reissue_client_certificate(
         "status": "reissued",
         "message": "Certificate reissued successfully. Client must download new config."
     }
+
+
+@router.post("/clients/{client_id}/certificates/revoke")
+async def revoke_all_client_certificates(
+    client_id: int,
+    body: ClientCertificateRevokeRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_permission("clients", "update"))
+):
+    """Revoke all active certificates for a client (admin-only).
+    
+    Marks all active (non-revoked) certificates as revoked and adds them to the persistent revocation list.
+    Optionally issues a new certificate after revocation.
+    
+    Args:
+        client_id: Client ID
+        body: Request body with reason and issue_new flag
+        
+    Returns:
+        Status with count of revoked certificates and optional new certificate info
+    """
+    from ..models.schemas import ClientCertificateRevokeResponse
+    
+    # Fetch client
+    client_result = await session.execute(
+        select(Client).where(Client.id == client_id)
+    )
+    client = client_result.scalar_one_or_none()
+    if not client:
+        raise HTTPException(status_code=404, detail="Client not found")
+    
+    # Fetch all active (non-revoked) certificates for this client
+    cert_result = await session.execute(
+        select(ClientCertificate).where(
+            ClientCertificate.client_id == client_id,
+            ClientCertificate.revoked == False
+        )
+    )
+    active_certs = cert_result.scalars().all()
+    
+    if not active_certs:
+        raise HTTPException(
+            status_code=400, 
+            detail="No active certificates to revoke for this client"
+        )
+    
+    # Use single timestamp for all revocations
+    revoked_at = datetime.utcnow()
+    revoked_fingerprints = []
+    
+    # Revoke all active certificates
+    for cert in active_certs:
+        # Mark as revoked in ClientCertificate table
+        cert.revoked = True
+        cert.revoked_at = revoked_at
+        
+        # Add to persistent RevokedCertificate table if fingerprint exists
+        if cert.fingerprint:
+            # Check if already in revoked_certificates table
+            existing = await session.execute(
+                select(RevokedCertificate).where(RevokedCertificate.fingerprint == cert.fingerprint)
+            )
+            if not existing.scalar_one_or_none():
+                revoked_cert = RevokedCertificate(
+                    fingerprint=cert.fingerprint,
+                    client_id=client_id,
+                    client_name=client.name,
+                    not_after=cert.not_after,
+                    revoked_at=revoked_at,
+                    revoked_reason=body.reason or "manual_revocation",
+                    revoked_by_user_id=user.id
+                )
+                session.add(revoked_cert)
+                revoked_fingerprints.append(cert.fingerprint)
+                logger.info(
+                    f"Adding certificate {cert.fingerprint[:12]}... to persistent revocation list "
+                    f"(bulk revocation by {user.email}, reason: {body.reason})"
+                )
+        else:
+            logger.warning(
+                f"Certificate ID {cert.id} for client {client_id} ({client.name}) "
+                f"revoked locally but CANNOT be added to distributed revocation list (missing fingerprint)."
+            )
+    
+    try:
+        await session.commit()
+    except IntegrityError:
+        # Handle race condition: another process may have inserted one of these fingerprints
+        await session.rollback()
+        logger.warning(
+            f"One or more certificates from client {client_id} already in revocation list (race condition), "
+            f"retrying with idempotent insert"
+        )
+        
+        # Re-apply revoked flags and add only missing fingerprints
+        # Reset revoked_fingerprints to rebuild it from actual insertions
+        revoked_fingerprints = []
+        for cert in active_certs:
+            cert.revoked = True
+            cert.revoked_at = revoked_at
+            
+            if cert.fingerprint:
+                existing = await session.execute(
+                    select(RevokedCertificate).where(RevokedCertificate.fingerprint == cert.fingerprint)
+                )
+                if not existing.scalar_one_or_none():
+                    revoked_cert = RevokedCertificate(
+                        fingerprint=cert.fingerprint,
+                        client_id=client_id,
+                        client_name=client.name,
+                        not_after=cert.not_after,
+                        revoked_at=revoked_at,
+                        revoked_reason=body.reason or "manual_revocation",
+                        revoked_by_user_id=user.id
+                    )
+                    session.add(revoked_cert)
+                    revoked_fingerprints.append(cert.fingerprint)
+        await session.commit()
+    
+    # Update client config timestamp to trigger re-download
+    client.config_last_changed_at = revoked_at
+    await session.commit()
+    
+    new_certificate_issued = False
+    
+    # Optionally issue new certificate
+    if body.issue_new:
+        # Get IP assignment
+        ip_result = await session.execute(
+            select(IPAssignment).where(
+                IPAssignment.client_id == client_id,
+                IPAssignment.is_primary == True
+            ).order_by(IPAssignment.id)
+        )
+        ip_assignment = ip_result.scalar_one_or_none()
+        
+        if not ip_assignment:
+            # Try to get any IP assignment
+            ip_result = await session.execute(
+                select(IPAssignment).where(IPAssignment.client_id == client_id).order_by(IPAssignment.id)
+            )
+            ip_assignment = ip_result.scalar_one_or_none()
+        
+        if ip_assignment:
+            # Get active CA
+            now_ts = datetime.utcnow()
+            ca_result = await session.execute(
+                select(CACertificate).where(
+                    CACertificate.is_active == True,
+                    CACertificate.can_sign == True,
+                    CACertificate.not_after > now_ts
+                )
+            )
+            active_ca = ca_result.scalar_one_or_none()
+            
+            if active_ca:
+                # Determine CIDR from pool
+                cidr = "10.100.0.0/16"  # default
+                if ip_assignment.pool_id:
+                    pool_result = await session.execute(
+                        select(IPPool).where(IPPool.id == ip_assignment.pool_id)
+                    )
+                    pool = pool_result.scalar_one_or_none()
+                    if pool:
+                        cidr = pool.cidr
+                
+                import ipaddress
+                try:
+                    prefix = ipaddress.ip_network(cidr, strict=False).prefixlen
+                except Exception:
+                    prefix = 24
+                
+                # Determine cert version
+                settings_result = await session.execute(select(GlobalSettings))
+                settings_row = settings_result.scalars().first()
+                cert_version = getattr(settings_row, 'cert_version', 'v1') if settings_row else 'v1'
+                client_ip_version = getattr(client, 'ip_version', 'ipv4_only')
+                
+                requires_v2_features = client_ip_version in ['multi_ipv4', 'multi_ipv6', 'multi_both', 'dual_stack', 'ipv6_only']
+                if requires_v2_features and cert_version == 'v1':
+                    cert_version = 'v2'
+                
+                # For v2 or hybrid certs, gather all IPs
+                all_ips = []
+                if cert_version in ['v2', 'hybrid']:
+                    all_ip_rows = (await session.execute(
+                        select(IPAssignment)
+                        .where(IPAssignment.client_id == client.id)
+                        .order_by(IPAssignment.is_primary.desc(), IPAssignment.id)
+                    )).scalars().all()
+                    all_ips = [row.ip_address for row in all_ip_rows]
+                
+                # Generate new keypair and issue certificate
+                import subprocess
+                import tempfile
+                import os
+                
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    key_path = os.path.join(tmpdir, "host.key")
+                    pub_path = os.path.join(tmpdir, "host.pub")
+                    
+                    try:
+                        result = subprocess.run(
+                            ["nebula-cert", "keygen", "-out-key", key_path, "-out-pub", pub_path],
+                            check=True,
+                            capture_output=True,
+                            text=True,
+                            timeout=30
+                        )
+                    except subprocess.TimeoutExpired as exc:
+                        logger.error(
+                            "nebula-cert keygen timed out after 30 seconds",
+                            extra={
+                                "client_id": client_id,
+                                "timeout": 30,
+                            },
+                        )
+                        raise HTTPException(
+                            status_code=500,
+                            detail="Failed to generate nebula host keypair (timeout)",
+                        ) from exc
+                    except subprocess.CalledProcessError as exc:
+                        logger.error(
+                            "nebula-cert keygen failed",
+                            extra={
+                                "client_id": client_id,
+                                "returncode": exc.returncode,
+                                "stderr": exc.stderr,
+                                "stdout": exc.stdout,
+                            },
+                        )
+                        raise HTTPException(
+                            status_code=500,
+                            detail="Failed to generate nebula host keypair",
+                        ) from exc
+                    
+                    with open(pub_path, "r") as f:
+                        public_key_pem = f.read()
+                    
+                    cert_manager = CertManager(session)
+                    await cert_manager.issue_or_rotate_client_cert(
+                        client=client,
+                        public_key_str=public_key_pem,
+                        client_ip=ip_assignment.ip_address,
+                        cidr_prefix=prefix,
+                        cert_version=cert_version,
+                        all_ips=all_ips or None
+                    )
+                
+                await session.commit()
+                new_certificate_issued = True
+                logger.info(f"Issued new certificate for client {client_id} after bulk revocation")
+            else:
+                logger.warning(f"Cannot issue new certificate for client {client_id}: No active CA available")
+        else:
+            logger.warning(f"Cannot issue new certificate for client {client_id}: No IP assignment")
+    
+    return ClientCertificateRevokeResponse(
+        status="revoked",
+        revoked_count=len(active_certs),
+        revoked_fingerprints=[fp[:12] + "..." for fp in revoked_fingerprints],
+        message=f"Revoked {len(active_certs)} certificate(s)" + 
+                (f" and issued new certificate" if new_certificate_issued else ""),
+        new_certificate_issued=new_certificate_issued
+    )
 
 
 @router.post("/clients/{client_id}/certificates/{cert_id}/revoke")

--- a/server/tests/test_certificate_revoke_all.py
+++ b/server/tests/test_certificate_revoke_all.py
@@ -1,0 +1,386 @@
+"""
+Test POST /api/v1/clients/{client_id}/certificates/revoke endpoint.
+
+Tests bulk certificate revocation functionality.
+"""
+import pytest
+import shutil
+from datetime import datetime, timedelta
+from sqlalchemy import select
+from app.models.client import ClientCertificate, RevokedCertificate
+
+
+@pytest.mark.skipif(shutil.which("nebula-cert") is None, reason="nebula-cert not installed")
+@pytest.mark.asyncio
+async def test_revoke_all_certificates_success(async_client, async_session, auth_headers):
+    """Test revoking all certificates for a client."""
+    # Create CA
+    ca_response = await async_client.post(
+        "/api/v1/ca/create",
+        json={
+            "name": "Test CA",
+            "duration_days": 365,
+            "version": "v1"
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert ca_response.status_code == 200
+    
+    # Create client
+    client_response = await async_client.post(
+        "/api/v1/clients",
+        json={
+            "name": "test-client",
+            "is_lighthouse": False,
+            "group_ids": [],
+            "pool_id": None
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert client_response.status_code == 200
+    client_id = client_response.json()["id"]
+    
+    # Wait for certificate to be created
+    await async_session.commit()
+    
+    # Check how many certificates exist
+    cert_result = await async_session.execute(
+        select(ClientCertificate).where(
+            ClientCertificate.client_id == client_id,
+            ClientCertificate.revoked == False
+        )
+    )
+    certs_before = cert_result.scalars().all()
+    assert len(certs_before) > 0, "Client should have at least one certificate"
+    
+    # Manually create additional certificates for testing
+    new_cert = ClientCertificate(
+        client_id=client_id,
+        pem_cert="FAKE_CERT_2",
+        fingerprint="abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
+        not_before=datetime.utcnow(),
+        not_after=datetime.utcnow() + timedelta(days=180),
+        issued_for_ip_cidr="10.0.0.2/24",
+        revoked=False
+    )
+    async_session.add(new_cert)
+    await async_session.commit()
+    
+    # Store the full fingerprint for later verification
+    test_cert_fingerprint = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
+    
+    # Verify we now have multiple certificates
+    cert_result = await async_session.execute(
+        select(ClientCertificate).where(
+            ClientCertificate.client_id == client_id,
+            ClientCertificate.revoked == False
+        )
+    )
+    certs_before = cert_result.scalars().all()
+    initial_cert_count = len(certs_before)
+    assert initial_cert_count >= 2, f"Should have at least 2 certificates, got {initial_cert_count}"
+    
+    # Revoke all certificates
+    revoke_response = await async_client.post(
+        f"/api/v1/clients/{client_id}/certificates/revoke",
+        json={
+            "reason": "Testing bulk revocation",
+            "issue_new": False
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert revoke_response.status_code == 200
+    revoke_data = revoke_response.json()
+    assert revoke_data["status"] == "revoked"
+    assert revoke_data["revoked_count"] == initial_cert_count
+    
+    # Strengthen fingerprint format checks
+    revoked_fingerprints = revoke_data["revoked_fingerprints"]
+    assert isinstance(revoked_fingerprints, list)
+    assert len(revoked_fingerprints) == initial_cert_count
+    assert all(isinstance(fp, str) for fp in revoked_fingerprints)
+    # API truncates fingerprints with fp[:12] + "..."
+    assert all(fp.endswith("...") for fp in revoked_fingerprints), "All fingerprints should end with '...'"
+    assert all(len(fp) == 15 for fp in revoked_fingerprints), "All fingerprints should be 15 chars (12 + '...')"
+    # Verify at least one known fingerprint appears truncated correctly
+    assert test_cert_fingerprint[:12] + "..." in revoked_fingerprints, \
+        f"Expected truncated fingerprint {test_cert_fingerprint[:12]}... in response"
+    
+    assert revoke_data["new_certificate_issued"] is False
+    
+    # Verify all certificates are now revoked
+    await async_session.commit()
+    cert_result = await async_session.execute(
+        select(ClientCertificate).where(
+            ClientCertificate.client_id == client_id,
+            ClientCertificate.revoked == False
+        )
+    )
+    active_certs = cert_result.scalars().all()
+    assert len(active_certs) == 0, "All certificates should be revoked"
+    
+    # Verify certificates were added to RevokedCertificate table
+    revoked_result = await async_session.execute(
+        select(RevokedCertificate).where(
+            RevokedCertificate.client_id == client_id
+        )
+    )
+    revoked_certs = revoked_result.scalars().all()
+    assert len(revoked_certs) == initial_cert_count
+
+
+@pytest.mark.skipif(shutil.which("nebula-cert") is None, reason="nebula-cert not installed")
+@pytest.mark.asyncio
+async def test_revoke_all_with_new_certificate(async_client, async_session, auth_headers):
+    """Test revoking all certificates and issuing a new one."""
+    # Create CA
+    ca_response = await async_client.post(
+        "/api/v1/ca/create",
+        json={
+            "name": "Test CA 2",
+            "duration_days": 365,
+            "version": "v1"
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert ca_response.status_code == 200
+    
+    # Create client
+    client_response = await async_client.post(
+        "/api/v1/clients",
+        json={
+            "name": "test-client-2",
+            "is_lighthouse": False,
+            "group_ids": [],
+            "pool_id": None
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert client_response.status_code == 200
+    client_id = client_response.json()["id"]
+    
+    await async_session.commit()
+    
+    # Get certificate count before revocation
+    cert_result = await async_session.execute(
+        select(ClientCertificate).where(
+            ClientCertificate.client_id == client_id,
+            ClientCertificate.revoked == False
+        )
+    )
+    certs_before = len(cert_result.scalars().all())
+    
+    # Revoke all certificates AND issue new one
+    revoke_response = await async_client.post(
+        f"/api/v1/clients/{client_id}/certificates/revoke",
+        json={
+            "reason": "Scheduled rotation",
+            "issue_new": True
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert revoke_response.status_code == 200
+    revoke_data = revoke_response.json()
+    assert revoke_data["status"] == "revoked"
+    assert revoke_data["revoked_count"] == certs_before
+    assert revoke_data["new_certificate_issued"] is True
+    assert "issued new certificate" in revoke_data["message"].lower()
+    
+    # Verify we have exactly 1 active certificate (the new one)
+    await async_session.commit()
+    cert_result = await async_session.execute(
+        select(ClientCertificate).where(
+            ClientCertificate.client_id == client_id,
+            ClientCertificate.revoked == False
+        )
+    )
+    active_certs = cert_result.scalars().all()
+    assert len(active_certs) == 1, "Should have exactly 1 new certificate"
+
+
+@pytest.mark.skipif(shutil.which("nebula-cert") is None, reason="nebula-cert not installed")
+@pytest.mark.asyncio
+async def test_revoke_all_no_active_certificates(async_client, async_session, auth_headers):
+    """Test revoking when there are no active certificates."""
+    # Create CA
+    ca_response = await async_client.post(
+        "/api/v1/ca/create",
+        json={
+            "name": "Test CA 3",
+            "duration_days": 365,
+            "version": "v1"
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert ca_response.status_code == 200
+    
+    # Create client
+    client_response = await async_client.post(
+        "/api/v1/clients",
+        json={
+            "name": "test-client-3",
+            "is_lighthouse": False,
+            "group_ids": [],
+            "pool_id": None
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert client_response.status_code == 200
+    client_id = client_response.json()["id"]
+    
+    await async_session.commit()
+    
+    # Revoke all certificates first time
+    revoke_response = await async_client.post(
+        f"/api/v1/clients/{client_id}/certificates/revoke",
+        json={
+            "reason": "First revocation",
+            "issue_new": False
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert revoke_response.status_code == 200
+    
+    # Try to revoke again (should fail - no active certificates)
+    revoke_response2 = await async_client.post(
+        f"/api/v1/clients/{client_id}/certificates/revoke",
+        json={
+            "reason": "Second revocation",
+            "issue_new": False
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert revoke_response2.status_code == 400
+    assert "no active certificates" in revoke_response2.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_revoke_all_client_not_found(async_client, auth_headers):
+    """Test revoking certificates for non-existent client."""
+    # Try to revoke certificates for non-existent client
+    revoke_response = await async_client.post(
+        "/api/v1/clients/99999/certificates/revoke",
+        json={
+            "reason": "Test",
+            "issue_new": False
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert revoke_response.status_code == 404
+    assert "not found" in revoke_response.json()["detail"].lower()
+
+
+@pytest.mark.skipif(shutil.which("nebula-cert") is None, reason="nebula-cert not installed")
+@pytest.mark.asyncio
+async def test_revoke_all_certificates_integrity_error_retry(async_client, async_session, auth_headers):
+    """Test revocation is idempotent when RevokedCertificate row already exists (IntegrityError retry path)."""
+    # Create CA
+    ca_response = await async_client.post(
+        "/api/v1/ca/create",
+        json={
+            "name": "Retry CA",
+            "duration_days": 365,
+            "version": "v1"
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert ca_response.status_code == 200
+    ca_data = ca_response.json()
+    ca_id = ca_data["id"]
+
+    # Create client
+    client_response = await async_client.post(
+        "/api/v1/clients",
+        json={
+            "name": "retry-client",
+            "is_lighthouse": False,
+            "group_ids": [],
+            "pool_id": None
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert client_response.status_code == 200
+    client_id = client_response.json()["id"]
+    
+    await async_session.commit()
+
+    # Manually create a second certificate for this client
+    second_cert = ClientCertificate(
+        client_id=client_id,
+        pem_cert="FAKE_CERT_RETRY",
+        fingerprint="retry123456retry123456retry123456retry123456retry123456retry123456",
+        not_before=datetime.utcnow(),
+        not_after=datetime.utcnow() + timedelta(days=180),
+        issued_for_ip_cidr="10.0.0.3/24",
+        revoked=False
+    )
+    async_session.add(second_cert)
+    await async_session.commit()
+
+    # Load certificates from DB so we can pre-create a conflicting RevokedCertificate
+    result = await async_session.execute(
+        select(ClientCertificate).where(
+            ClientCertificate.client_id == client_id,
+            ClientCertificate.revoked == False
+        ).order_by(ClientCertificate.id)
+    )
+    client_certs = result.scalars().all()
+    assert len(client_certs) >= 2, f"Should have at least 2 certificates, got {len(client_certs)}"
+
+    # Pre-insert a RevokedCertificate for the first certificate fingerprint
+    first_fingerprint = client_certs[0].fingerprint
+    async_session.add(
+        RevokedCertificate(
+            fingerprint=first_fingerprint,
+            client_id=client_id,
+            client_name="retry-client",
+            not_after=client_certs[0].not_after,
+            revoked_at=datetime.utcnow(),
+            revoked_reason="pre_existing",
+            revoked_by_user_id=1
+        )
+    )
+    await async_session.commit()
+
+    # Now call the bulk revoke endpoint; the service should hit IntegrityError on insert
+    # and then retry inserting only missing fingerprints.
+    revoke_response = await async_client.post(
+        f"/api/v1/clients/{client_id}/certificates/revoke",
+        json={
+            "reason": "Testing retry path",
+            "issue_new": False
+        },
+        cookies=auth_headers["cookies"]
+    )
+    assert revoke_response.status_code == 200
+    revoke_data = revoke_response.json()
+    assert revoke_data["status"] == "revoked"
+    assert revoke_data["revoked_count"] == len(client_certs)
+
+    # All client certificates should now be marked revoked.
+    await async_session.commit()
+    result = await async_session.execute(
+        select(ClientCertificate)
+        .where(ClientCertificate.client_id == client_id)
+        .order_by(ClientCertificate.id)
+    )
+    updated_certs = result.scalars().all()
+    assert len(updated_certs) >= 2
+    assert all(cert.revoked is True for cert in updated_certs), "All certificates should be marked revoked"
+    assert all(cert.revoked_at is not None for cert in updated_certs), "All certificates should have revoked_at timestamp"
+
+    # There should be exactly one RevokedCertificate per certificate fingerprint
+    # (no duplicates, even for the pre-existing fingerprint).
+    result = await async_session.execute(
+        select(RevokedCertificate)
+        .where(RevokedCertificate.fingerprint.in_([c.fingerprint for c in updated_certs if c.fingerprint]))
+        .order_by(RevokedCertificate.fingerprint)
+    )
+    revoked_rows = result.scalars().all()
+    assert len(revoked_rows) == len([c for c in updated_certs if c.fingerprint]), \
+        "Should have one RevokedCertificate row per certificate with fingerprint"
+    revoked_fingerprints_set = {row.fingerprint for row in revoked_rows}
+    expected_fingerprints = {c.fingerprint for c in updated_certs if c.fingerprint}
+    assert revoked_fingerprints_set == expected_fingerprints, \
+        "All certificate fingerprints should be in RevokedCertificate table exactly once"
+


### PR DESCRIPTION
## Summary by Sourcery

Add an API endpoint to revoke all active certificates for a client, optionally issuing a new certificate, and cover it with request/response models and tests.

New Features:
- Introduce POST /clients/{client_id}/certificates/revoke endpoint to bulk-revoke all active certificates for a client with optional automatic re-issuance of a new certificate.

Enhancements:
- Record bulk-revoked certificates in the persistent revocation list and update client configuration timestamps to trigger config refresh.

Documentation:
- Define request and response schema models for bulk client certificate revocation, including reason and new-certificate metadata.

Tests:
- Add integration-style tests verifying successful bulk revocation, revocation with new certificate issuance, handling of missing active certificates, and revocation for non-existent clients.

<!-- kumpeapps-issue-autoclose -->
Closes #318